### PR TITLE
Use SSH forwarding for TF remote execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ This terraform script with setup the DCOS cluster in AWS.
   - public_security_group_id
   - public_subnet_id
   - vpc_id
-  - aws_key_path
-  - aws_key_name
+  - key_pair_name  
+  We have an [Iac-manager][iac-manager] which can do this task.
 - Install terraform in the machine from [here][terraform-install].
+- Public Key Access with Agent support/ Agent Forwarding
+  ssh-add ~/.ssh/id_rsa
+  ssh -A user@ip
 
 #### Steps to install DCOS
 - Clone this repo .

--- a/agent.tf
+++ b/agent.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "agent" {
   ami = "${lookup(var.amis, var.aws_region)}"
   availability_zone = "${var.aws_region}a"
   instance_type = "${var.instance_type.agent}"
-  key_name = "${var.aws_key_name}"
+  key_name = "${var.key_pair_name}"
   vpc_security_group_ids = [
     "${aws_security_group.private.id}"]
   subnet_id = "${aws_subnet.availability-zone-private.id}"
@@ -12,8 +12,7 @@ resource "aws_instance" "agent" {
   user_data = "${file("agent-cloud-config.yaml")}"
   connection {
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   root_block_device {
     volume_size = "${var.dcos_agent_disk_size}"
@@ -33,8 +32,7 @@ resource "null_resource" "setup-agent" {
   connection {
     host = "${element(aws_instance.agent.*.private_ip, count.index)}"
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   provisioner "file" {
     source = "./do-install.sh"

--- a/bootstrap.tf
+++ b/bootstrap.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "bootstrap" {
   ami = "${lookup(var.centos_amis, var.aws_region)}"
   availability_zone = "${var.aws_region}a"
   instance_type = "${var.instance_type.bootstrap}"
-  key_name = "${var.aws_key_name}"
+  key_name = "${var.key_pair_name}"
   vpc_security_group_ids = ["${aws_security_group.private.id}"]
   subnet_id = "${aws_subnet.availability-zone-private.id}"
   source_dest_check = false
@@ -12,8 +12,7 @@ resource "aws_instance" "bootstrap" {
   }
   connection {
     user = "centos"
-    agent = false
-    private_key ="${file(var.aws_key_path)}"
+    agent = true
   }
   root_block_device {
     volume_size = "10"

--- a/master.tf
+++ b/master.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "master" {
   ami = "${lookup(var.amis, var.aws_region)}"
   availability_zone = "${var.aws_region}a"
   instance_type = "${var.instance_type.master}"
-  key_name = "${var.aws_key_name}"
+  key_name = "${var.key_pair_name}"
   vpc_security_group_ids = [
     "${aws_security_group.private.id}"]
   subnet_id = "${aws_subnet.availability-zone-private.id}"
@@ -11,8 +11,7 @@ resource "aws_instance" "master" {
   user_data = "${file("${lookup(var.master_user_data, signum(count.index))}")}"
   connection {
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   root_block_device {
     volume_size = "${var.dcos_master_disk_size}"
@@ -41,8 +40,7 @@ resource "null_resource" "setup-master" {
   connection {
     host = "${element(aws_instance.master.*.private_ip, count.index)}"
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   provisioner "file" {
     source = "./do-install.sh"

--- a/public-agent.tf
+++ b/public-agent.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "public-agent" {
   ami = "${lookup(var.amis, var.aws_region)}"
   availability_zone = "${var.aws_region}a"
   instance_type = "${var.instance_type.public-agent}"
-  key_name = "${var.aws_key_name}"
+  key_name = "${var.key_pair_name}"
   vpc_security_group_ids = [
     "${aws_security_group.private.id}"]
   subnet_id = "${aws_subnet.availability-zone-private.id}"
@@ -12,8 +12,7 @@ resource "aws_instance" "public-agent" {
   user_data = "${file("agent-cloud-config.yaml")}"
   connection {
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   root_block_device {
     volume_size = "${var.dcos_agent_disk_size}"
@@ -33,8 +32,7 @@ resource "null_resource" "setup-public-agent" {
   connection {
     host = "${element(aws_instance.public-agent.*.private_ip, count.index)}"
     user = "core"
-    agent = false
-    private_key = "${file(var.aws_key_path)}"
+    agent = true
   }
   provisioner "file" {
     source = "./do-install.sh"

--- a/variable.tf
+++ b/variable.tf
@@ -2,9 +2,7 @@ variable "aws_access_key" {
 }
 variable "aws_secret_key" {
 }
-variable "aws_key_path" {
-}
-variable "aws_key_name" {
+variable "key_pair_name" {
 }
 variable "dcos_installer_url" {
 }


### PR DESCRIPTION
Using agent forwarding, obviating the need for pem files.